### PR TITLE
btcjson/chainsvrresults: parse witness as string slice

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -317,7 +317,7 @@ type Vin struct {
 	Vout      uint32     `json:"vout"`
 	ScriptSig *ScriptSig `json:"scriptSig"`
 	Sequence  uint32     `json:"sequence"`
-	Witness   string     `json:"txinwitness"`
+	Witness   []string   `json:"txinwitness"`
 }
 
 // IsCoinBase returns a bool to show if a Vin is a Coinbase one or not.
@@ -335,9 +335,9 @@ func (v *Vin) HasWitness() bool {
 func (v *Vin) MarshalJSON() ([]byte, error) {
 	if v.IsCoinBase() {
 		coinbaseStruct := struct {
-			Coinbase string `json:"coinbase"`
-			Sequence uint32 `json:"sequence"`
-			Witness  string `json:"witness,omitempty"`
+			Coinbase string   `json:"coinbase"`
+			Sequence uint32   `json:"sequence"`
+			Witness  []string `json:"witness,omitempty"`
 		}{
 			Coinbase: v.Coinbase,
 			Sequence: v.Sequence,
@@ -351,7 +351,7 @@ func (v *Vin) MarshalJSON() ([]byte, error) {
 			Txid      string     `json:"txid"`
 			Vout      uint32     `json:"vout"`
 			ScriptSig *ScriptSig `json:"scriptSig"`
-			Witness   string     `json:"txinwitness"`
+			Witness   []string   `json:"txinwitness"`
 			Sequence  uint32     `json:"sequence"`
 		}{
 			Txid:      v.Txid,
@@ -389,7 +389,7 @@ type VinPrevOut struct {
 	Txid      string     `json:"txid"`
 	Vout      uint32     `json:"vout"`
 	ScriptSig *ScriptSig `json:"scriptSig"`
-	Witness   string     `json:"txinwitness"`
+	Witness   []string   `json:"txinwitness"`
 	PrevOut   *PrevOut   `json:"prevOut"`
 	Sequence  uint32     `json:"sequence"`
 }
@@ -423,7 +423,7 @@ func (v *VinPrevOut) MarshalJSON() ([]byte, error) {
 			Txid      string     `json:"txid"`
 			Vout      uint32     `json:"vout"`
 			ScriptSig *ScriptSig `json:"scriptSig"`
-			Witness   string     `json:"txinwitness"`
+			Witness   []string   `json:"txinwitness"`
 			PrevOut   *PrevOut   `json:"prevOut,omitempty"`
 			Sequence  uint32     `json:"sequence"`
 		}{

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -642,7 +642,7 @@ func createVinList(mtx *wire.MsgTx) []btcjson.Vin {
 		txIn := mtx.TxIn[0]
 		vinList[0].Coinbase = hex.EncodeToString(txIn.SignatureScript)
 		vinList[0].Sequence = txIn.Sequence
-		vinList[0].Witness = witnessToSring(txIn.Witness)
+		vinList[0].Witness = witnessToHex(txIn.Witness)
 		return vinList
 	}
 
@@ -662,27 +662,26 @@ func createVinList(mtx *wire.MsgTx) []btcjson.Vin {
 		}
 
 		if mtx.HasWitness() {
-			vinEntry.Witness = witnessToSring(txIn.Witness)
+			vinEntry.Witness = witnessToHex(txIn.Witness)
 		}
 	}
 
 	return vinList
 }
 
-// witnessToSring formats the passed witness stack as a string to be used
-// within a JSON response. The witness is encoded as a single string with
-// spaces separating each witness element.
-func witnessToSring(witness wire.TxWitness) string {
-	var b bytes.Buffer
-	for i, wit := range witness {
-		if i > 0 {
-			b.WriteString(" ")
-		}
-
-		b.WriteString(hex.EncodeToString(wit))
+// witnessToHex formats the passed witness stack as a slice of hex-encoded
+// strings to be used in the JSON response.
+func witnessToHex(witness wire.TxWitness) []string {
+	if len(witness) == 0 {
+		return nil
 	}
 
-	return b.String()
+	results := make([]string, 0, len(witness))
+	for _, wit := range witness {
+		results = append(results, hex.EncodeToString(wit))
+	}
+
+	return results
 }
 
 // createVoutList returns a slice of JSON objects for the outputs of the passed
@@ -2902,7 +2901,7 @@ func createVinListPrevOut(s *rpcServer, mtx *wire.MsgTx, chainParams *chaincfg.P
 		}
 
 		if len(txIn.Witness) != 0 {
-			vinEntry.Witness = witnessToSring(txIn.Witness)
+			vinEntry.Witness = witnessToHex(txIn.Witness)
 		}
 
 		// Add the entry to the list now if it already passed the filter


### PR DESCRIPTION
This commit fixes a divergence between btcd and ltcd in
the expected witness return types when querying for
transactions over rpc. The fix returns the behavior to
match btcd, by treating witnesses as an array of strings
instead of a single string. This ensures that both
btcd and ltcd remain compatible from the client side.