### PR TITLE
chaincfg: change testnet4 script hash address to Q prefix version byte

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -468,7 +468,7 @@ var TestNet4Params = Params{
 
 	// Address encoding magics
 	PubKeyHashAddrID:        0x6f, // starts with m or n
-	ScriptHashAddrID:        0xc4, // starts with 2
+	ScriptHashAddrID:        0x3a, // starts with Q
 	WitnessPubKeyHashAddrID: 0x52, // starts with QW
 	WitnessScriptHashAddrID: 0x31, // starts with T7n
 	PrivateKeyID:            0xef, // starts with 9 (uncompressed) or c (compressed)


### PR DESCRIPTION
https://github.com/litecoin-project/litecoin/commit/cbf7b9c79df9a49f796e0020d02b81c85c3f36e9#diff-64cbe1ad5465e13bc59ee8bb6f3de2e7

from litecoind 0.16 commit
base58Prefixes[SCRIPT_ADDRESS2] = std::vector<unsigned char>(1,58);